### PR TITLE
fix: secure crawl endpoint against unauthorized external triggers

### DIFF
--- a/src/app/api/crawl/route.ts
+++ b/src/app/api/crawl/route.ts
@@ -41,13 +41,25 @@ export async function POST(request: NextRequest) {
     const body = await request.json().catch(() => ({}));
     const { source, manual } = body as { source?: string; manual?: boolean };
 
-    // Authorization: allow CRON_SECRET for scheduled runs, or same-origin requests for manual triggers
+    // Authorization:
+    // 1. Scheduled runs (GitHub Actions): Bearer CRON_SECRET in Authorization header
+    // 2. Manual triggers from the dashboard UI: same-origin request verified via Origin header
     const authHeader = request.headers.get('authorization');
     const cronSecret = process.env.CRON_SECRET;
-    const isAuthorizedCron = cronSecret && authHeader === `Bearer ${cronSecret}`;
-    const isManualTrigger = manual === true;
+    const isAuthorizedCron = !!(cronSecret && authHeader === `Bearer ${cronSecret}`);
 
-    if (!isAuthorizedCron && !isManualTrigger) {
+    // For manual triggers, verify same-origin by checking the Origin header matches
+    // the request host. Browsers always send Origin on cross-origin fetches and
+    // omit or set it to the page origin for same-origin requests.
+    const requestHost = request.headers.get('host') || '';
+    const originHeader = request.headers.get('origin') || '';
+    const isSameOriginManual =
+      manual === true &&
+      !!originHeader &&
+      (originHeader === `https://${requestHost}` ||
+        originHeader === `http://${requestHost}`);
+
+    if (!isAuthorizedCron && !isSameOriginManual) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 


### PR DESCRIPTION
## Summary
Fixes #1 (P0 security fix)

## Problem
The `/api/crawl` endpoint accepted any request with `manual: true` in the body without any authentication. This meant anyone who knew the endpoint URL could trigger an unlimited number of crawl jobs from outside the app.

## Solution
Replaced the unconditional `manual: true` bypass with a proper same-origin check using the `Origin` request header:
- **GitHub Actions (scheduled):** Bearer `CRON_SECRET` token — unchanged
- **Dashboard UI (manual trigger):** Origin header must match the request host — only same-site browser requests pass
- All other requests → 401 Unauthorized

## Testing
- Dashboard '지금 수집하기' button: still works (browser sends matching Origin)
- GitHub Actions cron: still works (uses CRON_SECRET)
- External `curl` with `manual: true`: now returns 401

## Notes
- No breaking changes to the existing UX
- No new env vars required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manual trigger requests now require additional verification to proceed
  * Cron and scheduled task authorization enhanced with stricter validation requirements
  * Improved handling and rejection of unauthorized API requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->