### PR TITLE
layout: body-level padding pattern, remove max-w from sidebar layout

### DIFF
--- a/src/app/opportunities/page.tsx
+++ b/src/app/opportunities/page.tsx
@@ -135,8 +135,7 @@ export default function OpportunitiesPage() {
   };
 
   return (
-    <div className="bg-gray-50 min-h-screen pb-32 md:pb-8">
-      <div className="p-6 md:p-10 lg:p-12">
+    <>
         {/* Header */}
         <div className="mb-10">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">기회</h1>
@@ -272,7 +271,6 @@ export default function OpportunitiesPage() {
             )}
           </>
         )}
-      </div>
 
       {/* Report Modal */}
       <ReportModal
@@ -283,6 +281,6 @@ export default function OpportunitiesPage() {
         }}
         opportunityId={reportingOpportunity?.id}
       />
-    </div>
+    </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -160,7 +160,7 @@ export default function Dashboard() {
   ];
 
   return (
-    <div className="min-h-screen py-6 md:py-8">
+    <>
       {/* Header row */}
       <div className="flex items-center justify-between mb-6">
         <div>
@@ -286,6 +286,6 @@ export default function Dashboard() {
         }}
         opportunityId={reportingOpportunity?.id}
       />
-    </div>
+    </>
   );
 }

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -224,7 +224,7 @@ export default function PortfolioPage() {
   // Auth loading state
   if (authLoading) {
     return (
-      <div className="bg-white min-h-screen flex items-center justify-center">
+      <div className="flex items-center justify-center py-24">
         <div className="text-center">
           <Loader2 size={40} className="animate-spin text-indigo-600 mx-auto mb-4" />
           <p className="text-gray-600">로딩 중...</p>
@@ -236,7 +236,7 @@ export default function PortfolioPage() {
   // Not logged in — show login prompt
   if (!user) {
     return (
-      <div className="bg-white min-h-screen flex items-center justify-center p-4">
+      <div className="flex items-center justify-center py-16 px-4">
         <div className="max-w-md w-full text-center">
           <div className="w-20 h-20 bg-gradient-to-br from-indigo-100 to-blue-100 rounded-full flex items-center justify-center mx-auto mb-6">
             <Briefcase size={36} className="text-indigo-600" />
@@ -264,7 +264,7 @@ export default function PortfolioPage() {
   // Data loading state
   if (dataLoading) {
     return (
-      <div className="bg-white min-h-screen flex items-center justify-center">
+      <div className="flex items-center justify-center py-24">
         <div className="text-center">
           <Loader2 size={40} className="animate-spin text-indigo-600 mx-auto mb-4" />
           <p className="text-gray-600">포트폴리오를 불러오는 중...</p>
@@ -409,8 +409,7 @@ export default function PortfolioPage() {
   );
 
   return (
-    <div className="bg-white min-h-screen">
-      <div className="max-w-7xl mx-auto p-6 md:p-10 lg:p-12">
+    <div>
         {/* PROFILE HEADER */}
         <div className="mb-12 bg-white rounded-lg border border-gray-200 shadow-sm p-8">
           <div className="flex flex-col md:flex-row gap-8">
@@ -843,7 +842,6 @@ export default function PortfolioPage() {
             </div>
           </div>
         </div>
-      </div>
     </div>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -181,7 +181,7 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="p-6 md:p-10 lg:p-12 max-w-4xl pb-32 md:pb-8">
+    <div>
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900 mb-2">설정</h1>

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -137,7 +137,7 @@ export default function SignalsPage() {
   };
 
   return (
-    <div className="p-6 md:p-10 lg:p-12 pb-32 md:pb-8">
+    <div>
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900 mb-2">신호</h1>

--- a/src/components/LayoutContent.tsx
+++ b/src/components/LayoutContent.tsx
@@ -188,8 +188,9 @@ export default function LayoutContent({ navigationItems, children }: LayoutConte
       )}
 
       {/* Main Content */}
-      <main id="main-content" className="flex-1 overflow-y-auto pb-20 md:pb-0" tabIndex={-1}>
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+      <main id="main-content" className="flex-1 overflow-y-auto" tabIndex={-1}>
+        {/* Body-level container: centering + padding lives HERE, once, for all pages */}
+        <div className="max-w-3xl mx-auto px-6 py-6 md:px-8 md:py-8 pb-24 md:pb-8">
           {children}
         </div>
       </main>

--- a/src/components/LayoutContent.tsx
+++ b/src/components/LayoutContent.tsx
@@ -189,8 +189,8 @@ export default function LayoutContent({ navigationItems, children }: LayoutConte
 
       {/* Main Content */}
       <main id="main-content" className="flex-1 overflow-y-auto" tabIndex={-1}>
-        {/* Body-level container: centering + padding lives HERE, once, for all pages */}
-        <div className="max-w-3xl mx-auto px-6 py-6 md:px-8 md:py-8 pb-24 md:pb-8">
+        {/* Body-level container: padding lives HERE, once, for all pages — no max-w inside sidebar */}
+        <div className="px-6 py-6 md:px-8 md:py-8 pb-24 md:pb-8">
           {children}
         </div>
       </main>


### PR DESCRIPTION
## Summary

Closes #15

Addresses Eunji feedback: 중앙 정렬 안 됨, width 이상함, body padding 요청

## Context

PR #14 (UX density improvements) was already merged to main. This PR contains the 2 follow-up commits that were not included in that merge:

1. **Centralize padding to layout level** — remove per-page `p-6 md:p-10` wrappers, layout owns padding
2. **Remove `max-w` + `mx-auto`** — sidebar layouts should not constrain main content width

## Before / After

```jsx
// Before (anti-pattern — PR #14 state)
<main>
  <div class="max-w-4xl mx-auto px-4">
    {children}  // each page also had p-6 md:p-10 lg:p-12

// After (Tailwind UI / Vercel sidebar pattern)
<main>
  <div class="px-6 py-6 md:px-8 md:py-8">
    {children}  // pages are content only
```

## Why no max-width

In a sidebar layout, the sidebar already occupies fixed width (`w-56`). Adding `max-w` + `mx-auto` on the remaining `flex-1` area creates asymmetric whitespace — content appears left-aligned on wide screens with a large gap on the right. Standard pattern (Tailwind UI, Linear, Vercel) uses padding only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 페이지 레이아웃 및 여백 구조를 간소화했습니다.
  * 여러 페이지에서 배경색과 패딩 스타일을 제거하여 더 깔끔한 레이아웃으로 개선했습니다.
  * 컨텐츠 컨테이너의 간격 설정을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->